### PR TITLE
Allow chaining of JAXB plugins within JAXWS

### DIFF
--- a/src/main/java/com/kscs/util/plugins/xjc/base/AbstractPlugin.java
+++ b/src/main/java/com/kscs/util/plugins/xjc/base/AbstractPlugin.java
@@ -144,7 +144,7 @@ public abstract class AbstractPlugin extends Plugin {
 	}
 
 	private boolean isEndOfPluginArgs(final String arg) {
-		return AbstractPlugin.XJC_STANDARD_ARGS.contains(arg) || arg.startsWith("-X");
+		return AbstractPlugin.XJC_STANDARD_ARGS.contains(arg) || arg.startsWith("-X") || arg.startsWith("-B-X");
 	}
 
 	@Override


### PR DESCRIPTION
Allow chaining of JAXB plugins within JAXWS by explicitly declaring -B-X as terminating options.

This fixes #25 on mklemm/jaxb2-rich-contract-plugin